### PR TITLE
Use IncreaseProcessedInstanceCount to determine if an import has completed

### DIFF
--- a/features/instance-completed.feature
+++ b/features/instance-completed.feature
@@ -72,7 +72,7 @@ Feature: Import-Cantabular-Dimension-Options
     And the call to add a dimension to the instance with id "instance-happy-01" is successful
     And the instance with id "instance-happy-01" is successfully updated
     And the job with id "job-happy-01" is successfully updated
-    And the instance with id "instance-happy-01" has 5 dimension options
+    And 2 out of 2 dimensions have been processed for instance "instance-happy-01" and job "job-happy-01"
 
     Then these instance-complete events are produced:
       | InstanceID        |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.0.2-beta
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta
 	github.com/ONSdigital/dp-component-test v0.3.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.40.0 h1:sAGie19I3/CZW8u+Bp2zTFSCmM32SQjayPibXEVBsLY=
 github.com/ONSdigital/dp-api-clients-go v1.40.0/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.0.2-beta h1:mz9si9ibyfRUELPhq+uJeyRcPcWtHeIThvHSL/kyqU0=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.0.2-beta/go.mod h1:zN8+84r1tWgyCmypku7JFN63nCMOGTIM26zf5GwHkJ4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta h1:Wbjibp0/LLoRewWQfmbWw26iKDixw+iiA42OQgRqTQ4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta/go.mod h1:zN8+84r1tWgyCmypku7JFN63nCMOGTIM26zf5GwHkJ4=
 github.com/ONSdigital/dp-component-test v0.3.1 h1:SAtMptv7m2+5RIBydo97RVESZETBRTd57jh3ngwrguo=
 github.com/ONSdigital/dp-component-test v0.3.1/go.mod h1:uf3ysJPRWHzi6YhNlN/vbhYr62w+zvGlNU/ublCDNgw=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/importapi"
 )
 
 //go:generate moq -out mock/cantabular-client.go -pkg mock . CantabularClient
@@ -17,11 +18,11 @@ type CantabularClient interface {
 
 type DatasetAPIClient interface {
 	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID, ifMatch string) (m dataset.Instance, eTag string, err error)
-	GetInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, q *dataset.QueryParams, ifMatch string) (m dataset.Dimensions, eTag string, err error)
 	PostInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data dataset.OptionPost, ifMatch string) (eTag string, err error)
 	PutInstanceState(ctx context.Context, serviceAuthToken, instanceID string, state dataset.State, ifMatch string) (eTag string, err error)
 }
 
 type ImportAPIClient interface {
 	UpdateImportJobState(ctx context.Context, jobID, serviceToken string, newState string) error
+	IncreaseProcessedInstanceCount(ctx context.Context, jobID, serviceToken, instanceID string) (procInst []importapi.ProcessedInstances, err error)
 }

--- a/handler/mock/dataset-api-client.go
+++ b/handler/mock/dataset-api-client.go
@@ -12,7 +12,6 @@ import (
 
 var (
 	lockDatasetAPIClientMockGetInstance            sync.RWMutex
-	lockDatasetAPIClientMockGetInstanceDimensions  sync.RWMutex
 	lockDatasetAPIClientMockPostInstanceDimensions sync.RWMutex
 	lockDatasetAPIClientMockPutInstanceState       sync.RWMutex
 )
@@ -30,9 +29,6 @@ var _ handler.DatasetAPIClient = &DatasetAPIClientMock{}
 //             GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
 // 	               panic("mock out the GetInstance method")
 //             },
-//             GetInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, q *dataset.QueryParams, ifMatch string) (dataset.Dimensions, string, error) {
-// 	               panic("mock out the GetInstanceDimensions method")
-//             },
 //             PostInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
 // 	               panic("mock out the PostInstanceDimensions method")
 //             },
@@ -48,9 +44,6 @@ var _ handler.DatasetAPIClient = &DatasetAPIClientMock{}
 type DatasetAPIClientMock struct {
 	// GetInstanceFunc mocks the GetInstance method.
 	GetInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error)
-
-	// GetInstanceDimensionsFunc mocks the GetInstanceDimensions method.
-	GetInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, q *dataset.QueryParams, ifMatch string) (dataset.Dimensions, string, error)
 
 	// PostInstanceDimensionsFunc mocks the PostInstanceDimensions method.
 	PostInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error)
@@ -72,19 +65,6 @@ type DatasetAPIClientMock struct {
 			CollectionID string
 			// InstanceID is the instanceID argument value.
 			InstanceID string
-			// IfMatch is the ifMatch argument value.
-			IfMatch string
-		}
-		// GetInstanceDimensions holds details about calls to the GetInstanceDimensions method.
-		GetInstanceDimensions []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ServiceAuthToken is the serviceAuthToken argument value.
-			ServiceAuthToken string
-			// InstanceID is the instanceID argument value.
-			InstanceID string
-			// Q is the q argument value.
-			Q *dataset.QueryParams
 			// IfMatch is the ifMatch argument value.
 			IfMatch string
 		}
@@ -165,53 +145,6 @@ func (mock *DatasetAPIClientMock) GetInstanceCalls() []struct {
 	lockDatasetAPIClientMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
 	lockDatasetAPIClientMockGetInstance.RUnlock()
-	return calls
-}
-
-// GetInstanceDimensions calls GetInstanceDimensionsFunc.
-func (mock *DatasetAPIClientMock) GetInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, q *dataset.QueryParams, ifMatch string) (dataset.Dimensions, string, error) {
-	if mock.GetInstanceDimensionsFunc == nil {
-		panic("DatasetAPIClientMock.GetInstanceDimensionsFunc: method is nil but DatasetAPIClient.GetInstanceDimensions was just called")
-	}
-	callInfo := struct {
-		Ctx              context.Context
-		ServiceAuthToken string
-		InstanceID       string
-		Q                *dataset.QueryParams
-		IfMatch          string
-	}{
-		Ctx:              ctx,
-		ServiceAuthToken: serviceAuthToken,
-		InstanceID:       instanceID,
-		Q:                q,
-		IfMatch:          ifMatch,
-	}
-	lockDatasetAPIClientMockGetInstanceDimensions.Lock()
-	mock.calls.GetInstanceDimensions = append(mock.calls.GetInstanceDimensions, callInfo)
-	lockDatasetAPIClientMockGetInstanceDimensions.Unlock()
-	return mock.GetInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, q, ifMatch)
-}
-
-// GetInstanceDimensionsCalls gets all the calls that were made to GetInstanceDimensions.
-// Check the length with:
-//     len(mockedDatasetAPIClient.GetInstanceDimensionsCalls())
-func (mock *DatasetAPIClientMock) GetInstanceDimensionsCalls() []struct {
-	Ctx              context.Context
-	ServiceAuthToken string
-	InstanceID       string
-	Q                *dataset.QueryParams
-	IfMatch          string
-} {
-	var calls []struct {
-		Ctx              context.Context
-		ServiceAuthToken string
-		InstanceID       string
-		Q                *dataset.QueryParams
-		IfMatch          string
-	}
-	lockDatasetAPIClientMockGetInstanceDimensions.RLock()
-	calls = mock.calls.GetInstanceDimensions
-	lockDatasetAPIClientMockGetInstanceDimensions.RUnlock()
 	return calls
 }
 

--- a/handler/mock/import-api-client.go
+++ b/handler/mock/import-api-client.go
@@ -5,12 +5,14 @@ package mock
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-api-clients-go/v2/importapi"
 	"github.com/ONSdigital/dp-import-cantabular-dimension-options/handler"
 	"sync"
 )
 
 var (
-	lockImportAPIClientMockUpdateImportJobState sync.RWMutex
+	lockImportAPIClientMockIncreaseProcessedInstanceCount sync.RWMutex
+	lockImportAPIClientMockUpdateImportJobState           sync.RWMutex
 )
 
 // Ensure, that ImportAPIClientMock does implement handler.ImportAPIClient.
@@ -23,6 +25,9 @@ var _ handler.ImportAPIClient = &ImportAPIClientMock{}
 //
 //         // make and configure a mocked handler.ImportAPIClient
 //         mockedImportAPIClient := &ImportAPIClientMock{
+//             IncreaseProcessedInstanceCountFunc: func(ctx context.Context, jobID string, serviceToken string, instanceID string) ([]importapi.ProcessedInstances, error) {
+// 	               panic("mock out the IncreaseProcessedInstanceCount method")
+//             },
 //             UpdateImportJobStateFunc: func(ctx context.Context, jobID string, serviceToken string, newState string) error {
 // 	               panic("mock out the UpdateImportJobState method")
 //             },
@@ -33,11 +38,25 @@ var _ handler.ImportAPIClient = &ImportAPIClientMock{}
 //
 //     }
 type ImportAPIClientMock struct {
+	// IncreaseProcessedInstanceCountFunc mocks the IncreaseProcessedInstanceCount method.
+	IncreaseProcessedInstanceCountFunc func(ctx context.Context, jobID string, serviceToken string, instanceID string) ([]importapi.ProcessedInstances, error)
+
 	// UpdateImportJobStateFunc mocks the UpdateImportJobState method.
 	UpdateImportJobStateFunc func(ctx context.Context, jobID string, serviceToken string, newState string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// IncreaseProcessedInstanceCount holds details about calls to the IncreaseProcessedInstanceCount method.
+		IncreaseProcessedInstanceCount []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// JobID is the jobID argument value.
+			JobID string
+			// ServiceToken is the serviceToken argument value.
+			ServiceToken string
+			// InstanceID is the instanceID argument value.
+			InstanceID string
+		}
 		// UpdateImportJobState holds details about calls to the UpdateImportJobState method.
 		UpdateImportJobState []struct {
 			// Ctx is the ctx argument value.
@@ -50,6 +69,49 @@ type ImportAPIClientMock struct {
 			NewState string
 		}
 	}
+}
+
+// IncreaseProcessedInstanceCount calls IncreaseProcessedInstanceCountFunc.
+func (mock *ImportAPIClientMock) IncreaseProcessedInstanceCount(ctx context.Context, jobID string, serviceToken string, instanceID string) ([]importapi.ProcessedInstances, error) {
+	if mock.IncreaseProcessedInstanceCountFunc == nil {
+		panic("ImportAPIClientMock.IncreaseProcessedInstanceCountFunc: method is nil but ImportAPIClient.IncreaseProcessedInstanceCount was just called")
+	}
+	callInfo := struct {
+		Ctx          context.Context
+		JobID        string
+		ServiceToken string
+		InstanceID   string
+	}{
+		Ctx:          ctx,
+		JobID:        jobID,
+		ServiceToken: serviceToken,
+		InstanceID:   instanceID,
+	}
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.Lock()
+	mock.calls.IncreaseProcessedInstanceCount = append(mock.calls.IncreaseProcessedInstanceCount, callInfo)
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.Unlock()
+	return mock.IncreaseProcessedInstanceCountFunc(ctx, jobID, serviceToken, instanceID)
+}
+
+// IncreaseProcessedInstanceCountCalls gets all the calls that were made to IncreaseProcessedInstanceCount.
+// Check the length with:
+//     len(mockedImportAPIClient.IncreaseProcessedInstanceCountCalls())
+func (mock *ImportAPIClientMock) IncreaseProcessedInstanceCountCalls() []struct {
+	Ctx          context.Context
+	JobID        string
+	ServiceToken string
+	InstanceID   string
+} {
+	var calls []struct {
+		Ctx          context.Context
+		JobID        string
+		ServiceToken string
+		InstanceID   string
+	}
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.RLock()
+	calls = mock.calls.IncreaseProcessedInstanceCount
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.RUnlock()
+	return calls
 }
 
 // UpdateImportJobState calls UpdateImportJobStateFunc.

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/importapi"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 )
 
@@ -47,5 +48,6 @@ type DatasetAPIClient interface {
 // ImportAPIClient defines the required Import API methods
 type ImportAPIClient interface {
 	UpdateImportJobState(ctx context.Context, jobID, serviceToken string, newState string) error
+	IncreaseProcessedInstanceCount(ctx context.Context, jobID, serviceToken, instanceID string) (procInst []importapi.ProcessedInstances, err error)
 	Checker(context.Context, *healthcheck.CheckState) error
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -39,7 +39,6 @@ type CantabularClient interface {
 // DatasetAPIClient defines the required Dataset API methods
 type DatasetAPIClient interface {
 	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID, ifMatch string) (m dataset.Instance, eTag string, err error)
-	GetInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, q *dataset.QueryParams, ifMatch string) (m dataset.Dimensions, eTag string, err error)
 	PostInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data dataset.OptionPost, ifMatch string) (eTag string, err error)
 	PutInstanceState(ctx context.Context, serviceAuthToken, instanceID string, state dataset.State, ifMatch string) (eTag string, err error)
 	Checker(context.Context, *healthcheck.CheckState) error

--- a/service/mock/dataset-api-client.go
+++ b/service/mock/dataset-api-client.go
@@ -14,7 +14,6 @@ import (
 var (
 	lockDatasetAPIClientMockChecker                sync.RWMutex
 	lockDatasetAPIClientMockGetInstance            sync.RWMutex
-	lockDatasetAPIClientMockGetInstanceDimensions  sync.RWMutex
 	lockDatasetAPIClientMockPostInstanceDimensions sync.RWMutex
 	lockDatasetAPIClientMockPutInstanceState       sync.RWMutex
 )
@@ -35,9 +34,6 @@ var _ service.DatasetAPIClient = &DatasetAPIClientMock{}
 //             GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
 // 	               panic("mock out the GetInstance method")
 //             },
-//             GetInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, q *dataset.QueryParams, ifMatch string) (dataset.Dimensions, string, error) {
-// 	               panic("mock out the GetInstanceDimensions method")
-//             },
 //             PostInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
 // 	               panic("mock out the PostInstanceDimensions method")
 //             },
@@ -56,9 +52,6 @@ type DatasetAPIClientMock struct {
 
 	// GetInstanceFunc mocks the GetInstance method.
 	GetInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error)
-
-	// GetInstanceDimensionsFunc mocks the GetInstanceDimensions method.
-	GetInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, q *dataset.QueryParams, ifMatch string) (dataset.Dimensions, string, error)
 
 	// PostInstanceDimensionsFunc mocks the PostInstanceDimensions method.
 	PostInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error)
@@ -87,19 +80,6 @@ type DatasetAPIClientMock struct {
 			CollectionID string
 			// InstanceID is the instanceID argument value.
 			InstanceID string
-			// IfMatch is the ifMatch argument value.
-			IfMatch string
-		}
-		// GetInstanceDimensions holds details about calls to the GetInstanceDimensions method.
-		GetInstanceDimensions []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ServiceAuthToken is the serviceAuthToken argument value.
-			ServiceAuthToken string
-			// InstanceID is the instanceID argument value.
-			InstanceID string
-			// Q is the q argument value.
-			Q *dataset.QueryParams
 			// IfMatch is the ifMatch argument value.
 			IfMatch string
 		}
@@ -215,53 +195,6 @@ func (mock *DatasetAPIClientMock) GetInstanceCalls() []struct {
 	lockDatasetAPIClientMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
 	lockDatasetAPIClientMockGetInstance.RUnlock()
-	return calls
-}
-
-// GetInstanceDimensions calls GetInstanceDimensionsFunc.
-func (mock *DatasetAPIClientMock) GetInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, q *dataset.QueryParams, ifMatch string) (dataset.Dimensions, string, error) {
-	if mock.GetInstanceDimensionsFunc == nil {
-		panic("DatasetAPIClientMock.GetInstanceDimensionsFunc: method is nil but DatasetAPIClient.GetInstanceDimensions was just called")
-	}
-	callInfo := struct {
-		Ctx              context.Context
-		ServiceAuthToken string
-		InstanceID       string
-		Q                *dataset.QueryParams
-		IfMatch          string
-	}{
-		Ctx:              ctx,
-		ServiceAuthToken: serviceAuthToken,
-		InstanceID:       instanceID,
-		Q:                q,
-		IfMatch:          ifMatch,
-	}
-	lockDatasetAPIClientMockGetInstanceDimensions.Lock()
-	mock.calls.GetInstanceDimensions = append(mock.calls.GetInstanceDimensions, callInfo)
-	lockDatasetAPIClientMockGetInstanceDimensions.Unlock()
-	return mock.GetInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, q, ifMatch)
-}
-
-// GetInstanceDimensionsCalls gets all the calls that were made to GetInstanceDimensions.
-// Check the length with:
-//     len(mockedDatasetAPIClient.GetInstanceDimensionsCalls())
-func (mock *DatasetAPIClientMock) GetInstanceDimensionsCalls() []struct {
-	Ctx              context.Context
-	ServiceAuthToken string
-	InstanceID       string
-	Q                *dataset.QueryParams
-	IfMatch          string
-} {
-	var calls []struct {
-		Ctx              context.Context
-		ServiceAuthToken string
-		InstanceID       string
-		Q                *dataset.QueryParams
-		IfMatch          string
-	}
-	lockDatasetAPIClientMockGetInstanceDimensions.RLock()
-	calls = mock.calls.GetInstanceDimensions
-	lockDatasetAPIClientMockGetInstanceDimensions.RUnlock()
 	return calls
 }
 

--- a/service/mock/import-api-client.go
+++ b/service/mock/import-api-client.go
@@ -5,14 +5,16 @@ package mock
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-api-clients-go/v2/importapi"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-import-cantabular-dimension-options/service"
 	"sync"
 )
 
 var (
-	lockImportAPIClientMockChecker              sync.RWMutex
-	lockImportAPIClientMockUpdateImportJobState sync.RWMutex
+	lockImportAPIClientMockChecker                        sync.RWMutex
+	lockImportAPIClientMockIncreaseProcessedInstanceCount sync.RWMutex
+	lockImportAPIClientMockUpdateImportJobState           sync.RWMutex
 )
 
 // Ensure, that ImportAPIClientMock does implement service.ImportAPIClient.
@@ -28,6 +30,9 @@ var _ service.ImportAPIClient = &ImportAPIClientMock{}
 //             CheckerFunc: func(in1 context.Context, in2 *healthcheck.CheckState) error {
 // 	               panic("mock out the Checker method")
 //             },
+//             IncreaseProcessedInstanceCountFunc: func(ctx context.Context, jobID string, serviceToken string, instanceID string) ([]importapi.ProcessedInstances, error) {
+// 	               panic("mock out the IncreaseProcessedInstanceCount method")
+//             },
 //             UpdateImportJobStateFunc: func(ctx context.Context, jobID string, serviceToken string, newState string) error {
 // 	               panic("mock out the UpdateImportJobState method")
 //             },
@@ -41,6 +46,9 @@ type ImportAPIClientMock struct {
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(in1 context.Context, in2 *healthcheck.CheckState) error
 
+	// IncreaseProcessedInstanceCountFunc mocks the IncreaseProcessedInstanceCount method.
+	IncreaseProcessedInstanceCountFunc func(ctx context.Context, jobID string, serviceToken string, instanceID string) ([]importapi.ProcessedInstances, error)
+
 	// UpdateImportJobStateFunc mocks the UpdateImportJobState method.
 	UpdateImportJobStateFunc func(ctx context.Context, jobID string, serviceToken string, newState string) error
 
@@ -52,6 +60,17 @@ type ImportAPIClientMock struct {
 			In1 context.Context
 			// In2 is the in2 argument value.
 			In2 *healthcheck.CheckState
+		}
+		// IncreaseProcessedInstanceCount holds details about calls to the IncreaseProcessedInstanceCount method.
+		IncreaseProcessedInstanceCount []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// JobID is the jobID argument value.
+			JobID string
+			// ServiceToken is the serviceToken argument value.
+			ServiceToken string
+			// InstanceID is the instanceID argument value.
+			InstanceID string
 		}
 		// UpdateImportJobState holds details about calls to the UpdateImportJobState method.
 		UpdateImportJobState []struct {
@@ -99,6 +118,49 @@ func (mock *ImportAPIClientMock) CheckerCalls() []struct {
 	lockImportAPIClientMockChecker.RLock()
 	calls = mock.calls.Checker
 	lockImportAPIClientMockChecker.RUnlock()
+	return calls
+}
+
+// IncreaseProcessedInstanceCount calls IncreaseProcessedInstanceCountFunc.
+func (mock *ImportAPIClientMock) IncreaseProcessedInstanceCount(ctx context.Context, jobID string, serviceToken string, instanceID string) ([]importapi.ProcessedInstances, error) {
+	if mock.IncreaseProcessedInstanceCountFunc == nil {
+		panic("ImportAPIClientMock.IncreaseProcessedInstanceCountFunc: method is nil but ImportAPIClient.IncreaseProcessedInstanceCount was just called")
+	}
+	callInfo := struct {
+		Ctx          context.Context
+		JobID        string
+		ServiceToken string
+		InstanceID   string
+	}{
+		Ctx:          ctx,
+		JobID:        jobID,
+		ServiceToken: serviceToken,
+		InstanceID:   instanceID,
+	}
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.Lock()
+	mock.calls.IncreaseProcessedInstanceCount = append(mock.calls.IncreaseProcessedInstanceCount, callInfo)
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.Unlock()
+	return mock.IncreaseProcessedInstanceCountFunc(ctx, jobID, serviceToken, instanceID)
+}
+
+// IncreaseProcessedInstanceCountCalls gets all the calls that were made to IncreaseProcessedInstanceCount.
+// Check the length with:
+//     len(mockedImportAPIClient.IncreaseProcessedInstanceCountCalls())
+func (mock *ImportAPIClientMock) IncreaseProcessedInstanceCountCalls() []struct {
+	Ctx          context.Context
+	JobID        string
+	ServiceToken string
+	InstanceID   string
+} {
+	var calls []struct {
+		Ctx          context.Context
+		JobID        string
+		ServiceToken string
+		InstanceID   string
+	}
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.RLock()
+	calls = mock.calls.IncreaseProcessedInstanceCount
+	lockImportAPIClientMockIncreaseProcessedInstanceCount.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Use import API `IncreaseProcessedInstanceCount` instead of dataset api `GetInstanceDimensions` to determine if an instance has been fully processed
- Use latest version of dp-api-clients-go, containing the new import api endpoint call
- Removed dataset api `GetInstanceDimensions` call
- If the import contains multiple instances, we only set the import state to completed if all instances have been processed
- Fixed tests accordingly

Also set the import job to failed state if an instance fails to be processed (fixed tests accordingly)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Tried a full import process, which failed due to the dataset api trying to write to dp-graph while setting `edition-complete` instance state. But if this call is commented in dataset api, the cantabular import works, and also sets the import to completed state in mongoDB.
If you want to try to run a successful import, please comment the following lines in dataset-api instance/instance.go line 263-267:
```
// if versionErr := s.AddVersionDetailsToInstance(ctx, currentInstance.InstanceID, datasetID, edition, instance.Version); versionErr != nil {
// 	log.Event(ctx, "update instance: datastore.AddVersionDetailsToInstance returned an error", log.ERROR, log.Error(versionErr), editionLogData)
// 	handleInstanceErr(ctx, versionErr, w, logData)
// 	return
// }
```
(this issue will be addressed in a separate pr)

### Who can review

Anyone