### PR TITLE
replaced Cantabular healthcheck with a placeholder (master)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	DatasetAPIURL                     string        `envconfig:"DATASET_API_URL"`
 	ImportAPIURL                      string        `envconfig:"IMPORT_API_URL"`
 	CantabularURL                     string        `envconfig:"CANTABULAR_URL"`
+	CantabularHealthcheckEnabled      bool          `envconfig:"CANTABULAR_HEALTHCHECK_ENABLED"`
 	ServiceAuthToken                  string        `envconfig:"SERVICE_AUTH_TOKEN"         json:"-"`
 	ComponentTestUseLogFile           bool          `envconfig:"COMPONENT_TEST_USE_LOG_FILE"`
 }
@@ -52,6 +53,7 @@ func Get() (*Config, error) {
 		DatasetAPIURL:                     "http://localhost:22000",
 		CantabularURL:                     "http://localhost:8491",
 		ImportAPIURL:                      "http://localhost:21800",
+		CantabularHealthcheckEnabled:      false,
 		ServiceAuthToken:                  "",
 		ComponentTestUseLogFile:           false,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
 				So(cfg.CantabularURL, ShouldEqual, "http://localhost:8491")
 				So(cfg.ImportAPIURL, ShouldEqual, "http://localhost:21800")
+				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.ServiceAuthToken, ShouldEqual, "")
 				So(cfg.ComponentTestUseLogFile, ShouldBeFalse)
 			})

--- a/service/service.go
+++ b/service/service.go
@@ -265,7 +265,13 @@ func (svc *Service) registerCheckers() error {
 		return fmt.Errorf("error adding check for Kafka producer: %w", err)
 	}
 
-	if err := hc.AddCheck("Cantabular", svc.CantabularClient.Checker); err != nil {
+	// TODO - when Cantabular server is deployed to Production, remove this placeholder
+	// and use the real Checker instead: svc.cantabularClient.Checker
+	placeholderChecker := func(ctx context.Context, state *healthcheck.CheckState) error {
+		state.Update(healthcheck.StatusOK, "Cantabular healthcheck placeholder", http.StatusOK)
+		return nil
+	}
+	if err := hc.AddCheck("Cantabular", placeholderChecker); err != nil {
 		return fmt.Errorf("error adding check for Cantabular: %w", err)
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -265,13 +265,16 @@ func (svc *Service) registerCheckers() error {
 		return fmt.Errorf("error adding check for Kafka producer: %w", err)
 	}
 
-	// TODO - when Cantabular server is deployed to Production, remove this placeholder
-	// and use the real Checker instead: svc.cantabularClient.Checker
-	placeholderChecker := func(ctx context.Context, state *healthcheck.CheckState) error {
-		state.Update(healthcheck.StatusOK, "Cantabular healthcheck placeholder", http.StatusOK)
-		return nil
+	// TODO - when Cantabular server is deployed to Production, remove this placeholder and the flag,
+	// and always use the real Checker instead: svc.CantabularClient.Checker
+	cantabularChecker := svc.CantabularClient.Checker
+	if !svc.Cfg.CantabularHealthcheckEnabled {
+		cantabularChecker = func(ctx context.Context, state *healthcheck.CheckState) error {
+			state.Update(healthcheck.StatusOK, "Cantabular healthcheck placeholder", http.StatusOK)
+			return nil
+		}
 	}
-	if err := hc.AddCheck("Cantabular", placeholderChecker); err != nil {
+	if err := hc.AddCheck("Cantabular", cantabularChecker); err != nil {
 		return fmt.Errorf("error adding check for Cantabular: %w", err)
 	}
 


### PR DESCRIPTION
### What

- Replaced Cantabular healthcheck Checker with a placeholder.
This needs to be done in order to release this service to production, where the Cantabular server is not running yet. Once it is running, we can undo this change and use the real Checker again.

### How to review

- Make sure code change makes sense
- Make sure unit tests pass
- (info) tested the`/health` endpoint locally and validated that a successful check with the placeholder text appears.

### Who can review

anyone