### PR TITLE
patch instance dimensions (options) in batches

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	CantabularHealthcheckEnabled      bool          `envconfig:"CANTABULAR_HEALTHCHECK_ENABLED"`
 	ServiceAuthToken                  string        `envconfig:"SERVICE_AUTH_TOKEN"         json:"-"`
 	ComponentTestUseLogFile           bool          `envconfig:"COMPONENT_TEST_USE_LOG_FILE"`
+	BatchSizeLimit                    int           `envconfig:"BATCH_SIZE_LIMIT"`
 }
 
 var cfg *Config
@@ -56,6 +57,7 @@ func Get() (*Config, error) {
 		CantabularHealthcheckEnabled:      false,
 		ServiceAuthToken:                  "",
 		ComponentTestUseLogFile:           false,
+		BatchSizeLimit:                    250, // maximum number of values sent to dataset APIs in a single patch call
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.ServiceAuthToken, ShouldEqual, "")
 				So(cfg.ComponentTestUseLogFile, ShouldBeFalse)
+				So(cfg.BatchSizeLimit, ShouldEqual, 250)
 			})
 
 			Convey("Then a second call to config should return the same config", func() {

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -64,7 +64,7 @@ func (c *Component) theFollowingCodebookIsAvailable(name, q string, cb *godog.Do
 // POST /instances/{id}/dimensions
 func (c *Component) theCallToAddInstanceDimensionIsSuccessful(id string) error {
 	c.DatasetAPI.NewHandler().
-		Post("/instances/"+id+"/dimensions").
+		Patch("/instances/"+id+"/dimensions").
 		Reply(http.StatusOK).
 		AddHeader("ETag", testETag)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12-0.20210824095131-dffc09423443
 	github.com/ONSdigital/dp-component-test v0.3.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-import v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.40.0 h1:sAGie19I3/CZW8u+Bp2zTFSCmM32SQjayPibXEVBsLY=
 github.com/ONSdigital/dp-api-clients-go v1.40.0/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta h1:YVM5n4wi4FBIM5Wx8BkU4Pu/Hzkv5oiwyG2V+ibN598=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta/go.mod h1:p9Ig0jUJmOXYpsZFZkb+mBeUgNBKoTiTVqHt1kJlVrM=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12-0.20210824095131-dffc09423443 h1:L7rV9JeLqn8GmVwItIDp56IQbxFUkI+o5PDVJ/lBYVU=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12-0.20210824095131-dffc09423443/go.mod h1:do31xNC5k22vAMnbnXGT9NH/7MLAsfR0qeTfiItw/mA=
 github.com/ONSdigital/dp-component-test v0.3.1 h1:SAtMptv7m2+5RIBydo97RVESZETBRTd57jh3ngwrguo=
 github.com/ONSdigital/dp-component-test v0.3.1/go.mod h1:uf3ysJPRWHzi6YhNlN/vbhYr62w+zvGlNU/ublCDNgw=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
@@ -338,6 +338,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a h1:KikTa6HtAK8cS1qjvUvvq4QO21QnwC+EfvB+OAuZ/ZU=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/handler/category-dimension-import.go
+++ b/handler/category-dimension-import.go
@@ -109,12 +109,14 @@ func (h *CategoryDimensionImport) Handle(ctx context.Context, e *event.CategoryD
 	// TODO we will probably need to replace this Post with a batched Patch dimension with arrays of options (for performance reasons if we have lots of dimension options), similar to what we did in Filter API.
 	attempt := 0
 	for i := 0; i < variable.Len; i++ {
-		eTag, err = h.datasets.PostInstanceDimensions(ctx, h.cfg.ServiceAuthToken, e.InstanceID, dataset.OptionPost{
-			Name:     variable.Name,
-			CodeList: variable.Name,     // TODO can we assume this?
-			Code:     variable.Codes[i], // TODO can we assume this?
-			Option:   variable.Codes[i],
-			Label:    variable.Labels[i],
+		eTag, err = h.datasets.PatchInstanceDimensions(ctx, h.cfg.ServiceAuthToken, e.InstanceID, []*dataset.OptionPost{
+			{
+				Name:     variable.Name,
+				CodeList: variable.Name,     // TODO can we assume this?
+				Code:     variable.Codes[i], // TODO can we assume this?
+				Option:   variable.Codes[i],
+				Label:    variable.Labels[i],
+			},
 		}, eTag)
 		if err != nil {
 			switch errPost := err.(type) {

--- a/handler/category-dimension-import_test.go
+++ b/handler/category-dimension-import_test.go
@@ -81,36 +81,42 @@ func TestHandle(t *testing.T) {
 			})
 
 			Convey("Then one Post call is performed to Dataset API for each Cantabular variable", func() {
-				So(datasetAPIClient.PostInstanceDimensionsCalls(), ShouldHaveLength, 3)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls(), ShouldHaveLength, 3)
 
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, testToken)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[0].Data, ShouldResemble, dataset.OptionPost{
-					Code:     "code1",
-					Option:   "code1",
-					Label:    "Code 1",
-					CodeList: "test-variable",
-					Name:     "test-variable",
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, testToken)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[0].Data, ShouldResemble, []*dataset.OptionPost{
+					{
+						Code:     "code1",
+						Option:   "code1",
+						Label:    "Code 1",
+						CodeList: "test-variable",
+						Name:     "test-variable",
+					},
 				})
 
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[1].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[1].ServiceAuthToken, ShouldEqual, testToken)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[1].Data, ShouldResemble, dataset.OptionPost{
-					Code:     "code2",
-					Option:   "code2",
-					Label:    "Code 2",
-					CodeList: "test-variable",
-					Name:     "test-variable",
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[1].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[1].ServiceAuthToken, ShouldEqual, testToken)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[1].Data, ShouldResemble, []*dataset.OptionPost{
+					{
+						Code:     "code2",
+						Option:   "code2",
+						Label:    "Code 2",
+						CodeList: "test-variable",
+						Name:     "test-variable",
+					},
 				})
 
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[2].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[2].ServiceAuthToken, ShouldEqual, testToken)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[2].Data, ShouldResemble, dataset.OptionPost{
-					Code:     "code3",
-					Option:   "code3",
-					Label:    "Code 3",
-					CodeList: "test-variable",
-					Name:     "test-variable",
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[2].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[2].ServiceAuthToken, ShouldEqual, testToken)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[2].Data, ShouldResemble, []*dataset.OptionPost{
+					{
+						Code:     "code3",
+						Option:   "code3",
+						Label:    "Code 3",
+						CodeList: "test-variable",
+						Name:     "test-variable",
+					},
 				})
 			})
 
@@ -160,7 +166,7 @@ func TestHandle(t *testing.T) {
 
 			Convey("Then the expected InstanceComplete event is sent to the kafka producer", func() {
 				expectedBytes, err := schema.InstanceComplete.Marshal(&event.InstanceComplete{
-					InstanceID: testInstanceID,
+					InstanceID:     testInstanceID,
 					CantabularBlob: testBlob,
 				})
 				So(err, ShouldBeNil)
@@ -211,7 +217,7 @@ func TestHandle(t *testing.T) {
 
 			Convey("Then the expected InstanceComplete event is sent to the kafka producer", func() {
 				expectedBytes, err := schema.InstanceComplete.Marshal(&event.InstanceComplete{
-					InstanceID: testInstanceID,
+					InstanceID:     testInstanceID,
 					CantabularBlob: testBlob,
 				})
 				So(err, ShouldBeNil)
@@ -257,8 +263,8 @@ func TestHandle(t *testing.T) {
 
 		ctblrClient := cantabularClientHappy()
 		datasetAPIClient := mock.DatasetAPIClientMock{}
-		datasetAPIClient.PostInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
-			switch len(datasetAPIClient.PostInstanceDimensionsCalls()) {
+		datasetAPIClient.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
+			switch len(datasetAPIClient.PatchInstanceDimensionsCalls()) {
 			case 0, 1:
 				return testETag, nil
 			case 2:
@@ -273,7 +279,7 @@ func TestHandle(t *testing.T) {
 					State: dataset.StateCompleted.String(),
 				},
 			}
-			switch len(datasetAPIClient.PostInstanceDimensionsCalls()) {
+			switch len(datasetAPIClient.PatchInstanceDimensionsCalls()) {
 			case 0, 1:
 				return inst, testETag, nil
 			default:
@@ -305,50 +311,58 @@ func TestHandle(t *testing.T) {
 			})
 
 			Convey("Then one Post call is performed to Dataset API for each Cantabular variable, repeating the one that failed due to the eTag mismatch", func() {
-				So(datasetAPIClient.PostInstanceDimensionsCalls(), ShouldHaveLength, 4)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls(), ShouldHaveLength, 4)
 
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, testToken)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[0].IfMatch, ShouldEqual, testETag)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[0].Data, ShouldResemble, dataset.OptionPost{
-					Code:     "code1",
-					Option:   "code1",
-					Label:    "Code 1",
-					CodeList: "test-variable",
-					Name:     "test-variable",
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, testToken)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[0].IfMatch, ShouldEqual, testETag)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[0].Data, ShouldResemble, []*dataset.OptionPost{
+					{
+						Code:     "code1",
+						Option:   "code1",
+						Label:    "Code 1",
+						CodeList: "test-variable",
+						Name:     "test-variable",
+					},
 				})
 
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[1].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[1].ServiceAuthToken, ShouldEqual, testToken)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[1].IfMatch, ShouldEqual, testETag)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[1].Data, ShouldResemble, dataset.OptionPost{
-					Code:     "code2",
-					Option:   "code2",
-					Label:    "Code 2",
-					CodeList: "test-variable",
-					Name:     "test-variable",
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[1].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[1].ServiceAuthToken, ShouldEqual, testToken)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[1].IfMatch, ShouldEqual, testETag)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[1].Data, ShouldResemble, []*dataset.OptionPost{
+					{
+						Code:     "code2",
+						Option:   "code2",
+						Label:    "Code 2",
+						CodeList: "test-variable",
+						Name:     "test-variable",
+					},
 				})
 
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[2].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[2].ServiceAuthToken, ShouldEqual, testToken)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[2].IfMatch, ShouldEqual, newETag)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[2].Data, ShouldResemble, dataset.OptionPost{
-					Code:     "code2",
-					Option:   "code2",
-					Label:    "Code 2",
-					CodeList: "test-variable",
-					Name:     "test-variable",
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[2].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[2].ServiceAuthToken, ShouldEqual, testToken)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[2].IfMatch, ShouldEqual, newETag)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[2].Data, ShouldResemble, []*dataset.OptionPost{
+					{
+						Code:     "code2",
+						Option:   "code2",
+						Label:    "Code 2",
+						CodeList: "test-variable",
+						Name:     "test-variable",
+					},
 				})
 
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[3].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[3].ServiceAuthToken, ShouldEqual, testToken)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[3].IfMatch, ShouldEqual, newETag)
-				So(datasetAPIClient.PostInstanceDimensionsCalls()[3].Data, ShouldResemble, dataset.OptionPost{
-					Code:     "code3",
-					Option:   "code3",
-					Label:    "Code 3",
-					CodeList: "test-variable",
-					Name:     "test-variable",
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[3].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[3].ServiceAuthToken, ShouldEqual, testToken)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[3].IfMatch, ShouldEqual, newETag)
+				So(datasetAPIClient.PatchInstanceDimensionsCalls()[3].Data, ShouldResemble, []*dataset.OptionPost{
+					{
+						Code:     "code3",
+						Option:   "code3",
+						Label:    "Code 3",
+						CodeList: "test-variable",
+						Name:     "test-variable",
+					},
 				})
 			})
 
@@ -500,7 +514,7 @@ func TestHandleFailure(t *testing.T) {
 
 		Convey("Where dataset API returns a 500 error on PostInstanceDimensions", func() {
 			errPostInstance := dataset.NewDatasetAPIResponse(&http.Response{StatusCode: http.StatusInternalServerError}, "uri")
-			datasetAPIClient.PostInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
+			datasetAPIClient.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
 				return "", errPostInstance
 			}
 			eventHandler := handler.NewCategoryDimensionImport(testCfg, &ctblrClient, &datasetAPIClient, &importAPIClient, nil)
@@ -518,7 +532,7 @@ func TestHandleFailure(t *testing.T) {
 
 		Convey("Where dataset API returns a generic error on PostInstanceDimensions", func() {
 			errPostInstance := errors.New("generic Dataset API Client Error")
-			datasetAPIClient.PostInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
+			datasetAPIClient.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
 				return "", errPostInstance
 			}
 			eventHandler := handler.NewCategoryDimensionImport(testCfg, &ctblrClient, &datasetAPIClient, &importAPIClient, nil)
@@ -536,7 +550,7 @@ func TestHandleFailure(t *testing.T) {
 
 		Convey("Where dataset API returns a Conflict error on PostInstanceDimensions and the instance has changed to state failed", func() {
 			errPostInstance := dataset.NewDatasetAPIResponse(&http.Response{StatusCode: http.StatusConflict}, "uri")
-			datasetAPIClient.PostInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
+			datasetAPIClient.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
 				return "", errPostInstance
 			}
 			datasetAPIClient.GetInstanceFunc = func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
@@ -585,7 +599,7 @@ func TestHandleFailure(t *testing.T) {
 			}()
 
 			errPostInstance := dataset.NewDatasetAPIResponse(&http.Response{StatusCode: http.StatusConflict}, "uri")
-			datasetAPIClient.PostInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
+			datasetAPIClient.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
 				return "", errPostInstance
 			}
 			eventHandler := handler.NewCategoryDimensionImport(testCfg, &ctblrClient, &datasetAPIClient, &importAPIClient, nil)
@@ -599,7 +613,7 @@ func TestHandleFailure(t *testing.T) {
 				})
 
 				Convey("Then the post instance dimensions is retried MaxConflictRetries times", func() {
-					So(datasetAPIClient.PostInstanceDimensionsCalls(), ShouldHaveLength, handler.MaxConflictRetries+1)
+					So(datasetAPIClient.PatchInstanceDimensionsCalls(), ShouldHaveLength, handler.MaxConflictRetries+1)
 				})
 
 				Convey("Then the random sleep is called MaxConflictRetries times with the expected attemt values", func() {
@@ -687,7 +701,7 @@ func TestHandleFailure(t *testing.T) {
 
 			Convey("Then the expected InstanceComplete event is sent to the kafka producer", func() {
 				expectedBytes, err := schema.InstanceComplete.Marshal(&event.InstanceComplete{
-					InstanceID: testInstanceID,
+					InstanceID:     testInstanceID,
 					CantabularBlob: testBlob,
 				})
 				So(err, ShouldBeNil)
@@ -720,9 +734,11 @@ var testCodebookResp = &cantabular.GetCodebookResponse{
 	},
 	Codebook: cantabular.Codebook{
 		cantabular.Variable{
-			Name:  "test-variable",
-			Label: "Test Variable",
-			Len:   3,
+			VariableBase: cantabular.VariableBase{
+				Name:  "test-variable",
+				Label: "Test Variable",
+			},
+			Len: 3,
 			Codes: []string{
 				"code1",
 				"code2",
@@ -765,7 +781,7 @@ func cantabularInvalidResponse() mock.CantabularClientMock {
 
 func datasetAPIClientHappy() mock.DatasetAPIClientMock {
 	return mock.DatasetAPIClientMock{
-		PostInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
+		PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
 			return testETag, nil
 		},
 		GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
@@ -780,7 +796,7 @@ func datasetAPIClientHappy() mock.DatasetAPIClientMock {
 
 func datasetAPIClientHappyLastDimension() mock.DatasetAPIClientMock {
 	return mock.DatasetAPIClientMock{
-		PostInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
+		PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
 			return testETag, nil
 		},
 		GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -18,7 +18,7 @@ type CantabularClient interface {
 
 type DatasetAPIClient interface {
 	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID, ifMatch string) (m dataset.Instance, eTag string, err error)
-	PostInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data dataset.OptionPost, ifMatch string) (eTag string, err error)
+	PatchInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data []*dataset.OptionPost, ifMatch string) (eTag string, err error)
 	PutInstanceState(ctx context.Context, serviceAuthToken, instanceID string, state dataset.State, ifMatch string) (eTag string, err error)
 }
 

--- a/handler/mock/dataset-api-client.go
+++ b/handler/mock/dataset-api-client.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	lockDatasetAPIClientMockGetInstance            sync.RWMutex
-	lockDatasetAPIClientMockPostInstanceDimensions sync.RWMutex
-	lockDatasetAPIClientMockPutInstanceState       sync.RWMutex
+	lockDatasetAPIClientMockGetInstance             sync.RWMutex
+	lockDatasetAPIClientMockPatchInstanceDimensions sync.RWMutex
+	lockDatasetAPIClientMockPutInstanceState        sync.RWMutex
 )
 
 // Ensure, that DatasetAPIClientMock does implement handler.DatasetAPIClient.
@@ -29,8 +29,8 @@ var _ handler.DatasetAPIClient = &DatasetAPIClientMock{}
 //             GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
 // 	               panic("mock out the GetInstance method")
 //             },
-//             PostInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
-// 	               panic("mock out the PostInstanceDimensions method")
+//             PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
+// 	               panic("mock out the PatchInstanceDimensions method")
 //             },
 //             PutInstanceStateFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
 // 	               panic("mock out the PutInstanceState method")
@@ -45,8 +45,8 @@ type DatasetAPIClientMock struct {
 	// GetInstanceFunc mocks the GetInstance method.
 	GetInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error)
 
-	// PostInstanceDimensionsFunc mocks the PostInstanceDimensions method.
-	PostInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error)
+	// PatchInstanceDimensionsFunc mocks the PatchInstanceDimensions method.
+	PatchInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error)
 
 	// PutInstanceStateFunc mocks the PutInstanceState method.
 	PutInstanceStateFunc func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error)
@@ -68,8 +68,8 @@ type DatasetAPIClientMock struct {
 			// IfMatch is the ifMatch argument value.
 			IfMatch string
 		}
-		// PostInstanceDimensions holds details about calls to the PostInstanceDimensions method.
-		PostInstanceDimensions []struct {
+		// PatchInstanceDimensions holds details about calls to the PatchInstanceDimensions method.
+		PatchInstanceDimensions []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// ServiceAuthToken is the serviceAuthToken argument value.
@@ -77,7 +77,7 @@ type DatasetAPIClientMock struct {
 			// InstanceID is the instanceID argument value.
 			InstanceID string
 			// Data is the data argument value.
-			Data dataset.OptionPost
+			Data []*dataset.OptionPost
 			// IfMatch is the ifMatch argument value.
 			IfMatch string
 		}
@@ -148,16 +148,16 @@ func (mock *DatasetAPIClientMock) GetInstanceCalls() []struct {
 	return calls
 }
 
-// PostInstanceDimensions calls PostInstanceDimensionsFunc.
-func (mock *DatasetAPIClientMock) PostInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
-	if mock.PostInstanceDimensionsFunc == nil {
-		panic("DatasetAPIClientMock.PostInstanceDimensionsFunc: method is nil but DatasetAPIClient.PostInstanceDimensions was just called")
+// PatchInstanceDimensions calls PatchInstanceDimensionsFunc.
+func (mock *DatasetAPIClientMock) PatchInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
+	if mock.PatchInstanceDimensionsFunc == nil {
+		panic("DatasetAPIClientMock.PatchInstanceDimensionsFunc: method is nil but DatasetAPIClient.PatchInstanceDimensions was just called")
 	}
 	callInfo := struct {
 		Ctx              context.Context
 		ServiceAuthToken string
 		InstanceID       string
-		Data             dataset.OptionPost
+		Data             []*dataset.OptionPost
 		IfMatch          string
 	}{
 		Ctx:              ctx,
@@ -166,32 +166,32 @@ func (mock *DatasetAPIClientMock) PostInstanceDimensions(ctx context.Context, se
 		Data:             data,
 		IfMatch:          ifMatch,
 	}
-	lockDatasetAPIClientMockPostInstanceDimensions.Lock()
-	mock.calls.PostInstanceDimensions = append(mock.calls.PostInstanceDimensions, callInfo)
-	lockDatasetAPIClientMockPostInstanceDimensions.Unlock()
-	return mock.PostInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, data, ifMatch)
+	lockDatasetAPIClientMockPatchInstanceDimensions.Lock()
+	mock.calls.PatchInstanceDimensions = append(mock.calls.PatchInstanceDimensions, callInfo)
+	lockDatasetAPIClientMockPatchInstanceDimensions.Unlock()
+	return mock.PatchInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, data, ifMatch)
 }
 
-// PostInstanceDimensionsCalls gets all the calls that were made to PostInstanceDimensions.
+// PatchInstanceDimensionsCalls gets all the calls that were made to PatchInstanceDimensions.
 // Check the length with:
-//     len(mockedDatasetAPIClient.PostInstanceDimensionsCalls())
-func (mock *DatasetAPIClientMock) PostInstanceDimensionsCalls() []struct {
+//     len(mockedDatasetAPIClient.PatchInstanceDimensionsCalls())
+func (mock *DatasetAPIClientMock) PatchInstanceDimensionsCalls() []struct {
 	Ctx              context.Context
 	ServiceAuthToken string
 	InstanceID       string
-	Data             dataset.OptionPost
+	Data             []*dataset.OptionPost
 	IfMatch          string
 } {
 	var calls []struct {
 		Ctx              context.Context
 		ServiceAuthToken string
 		InstanceID       string
-		Data             dataset.OptionPost
+		Data             []*dataset.OptionPost
 		IfMatch          string
 	}
-	lockDatasetAPIClientMockPostInstanceDimensions.RLock()
-	calls = mock.calls.PostInstanceDimensions
-	lockDatasetAPIClientMockPostInstanceDimensions.RUnlock()
+	lockDatasetAPIClientMockPatchInstanceDimensions.RLock()
+	calls = mock.calls.PatchInstanceDimensions
+	lockDatasetAPIClientMockPatchInstanceDimensions.RUnlock()
 	return calls
 }
 

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -39,7 +39,7 @@ type CantabularClient interface {
 // DatasetAPIClient defines the required Dataset API methods
 type DatasetAPIClient interface {
 	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID, ifMatch string) (m dataset.Instance, eTag string, err error)
-	PostInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data dataset.OptionPost, ifMatch string) (eTag string, err error)
+	PatchInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data []*dataset.OptionPost, ifMatch string) (eTag string, err error)
 	PutInstanceState(ctx context.Context, serviceAuthToken, instanceID string, state dataset.State, ifMatch string) (eTag string, err error)
 	Checker(context.Context, *healthcheck.CheckState) error
 }

--- a/service/mock/dataset-api-client.go
+++ b/service/mock/dataset-api-client.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	lockDatasetAPIClientMockChecker                sync.RWMutex
-	lockDatasetAPIClientMockGetInstance            sync.RWMutex
-	lockDatasetAPIClientMockPostInstanceDimensions sync.RWMutex
-	lockDatasetAPIClientMockPutInstanceState       sync.RWMutex
+	lockDatasetAPIClientMockChecker                 sync.RWMutex
+	lockDatasetAPIClientMockGetInstance             sync.RWMutex
+	lockDatasetAPIClientMockPatchInstanceDimensions sync.RWMutex
+	lockDatasetAPIClientMockPutInstanceState        sync.RWMutex
 )
 
 // Ensure, that DatasetAPIClientMock does implement service.DatasetAPIClient.
@@ -34,8 +34,8 @@ var _ service.DatasetAPIClient = &DatasetAPIClientMock{}
 //             GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
 // 	               panic("mock out the GetInstance method")
 //             },
-//             PostInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
-// 	               panic("mock out the PostInstanceDimensions method")
+//             PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
+// 	               panic("mock out the PatchInstanceDimensions method")
 //             },
 //             PutInstanceStateFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
 // 	               panic("mock out the PutInstanceState method")
@@ -53,8 +53,8 @@ type DatasetAPIClientMock struct {
 	// GetInstanceFunc mocks the GetInstance method.
 	GetInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error)
 
-	// PostInstanceDimensionsFunc mocks the PostInstanceDimensions method.
-	PostInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error)
+	// PatchInstanceDimensionsFunc mocks the PatchInstanceDimensions method.
+	PatchInstanceDimensionsFunc func(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error)
 
 	// PutInstanceStateFunc mocks the PutInstanceState method.
 	PutInstanceStateFunc func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error)
@@ -83,8 +83,8 @@ type DatasetAPIClientMock struct {
 			// IfMatch is the ifMatch argument value.
 			IfMatch string
 		}
-		// PostInstanceDimensions holds details about calls to the PostInstanceDimensions method.
-		PostInstanceDimensions []struct {
+		// PatchInstanceDimensions holds details about calls to the PatchInstanceDimensions method.
+		PatchInstanceDimensions []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// ServiceAuthToken is the serviceAuthToken argument value.
@@ -92,7 +92,7 @@ type DatasetAPIClientMock struct {
 			// InstanceID is the instanceID argument value.
 			InstanceID string
 			// Data is the data argument value.
-			Data dataset.OptionPost
+			Data []*dataset.OptionPost
 			// IfMatch is the ifMatch argument value.
 			IfMatch string
 		}
@@ -198,16 +198,16 @@ func (mock *DatasetAPIClientMock) GetInstanceCalls() []struct {
 	return calls
 }
 
-// PostInstanceDimensions calls PostInstanceDimensionsFunc.
-func (mock *DatasetAPIClientMock) PostInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, data dataset.OptionPost, ifMatch string) (string, error) {
-	if mock.PostInstanceDimensionsFunc == nil {
-		panic("DatasetAPIClientMock.PostInstanceDimensionsFunc: method is nil but DatasetAPIClient.PostInstanceDimensions was just called")
+// PatchInstanceDimensions calls PatchInstanceDimensionsFunc.
+func (mock *DatasetAPIClientMock) PatchInstanceDimensions(ctx context.Context, serviceAuthToken string, instanceID string, data []*dataset.OptionPost, ifMatch string) (string, error) {
+	if mock.PatchInstanceDimensionsFunc == nil {
+		panic("DatasetAPIClientMock.PatchInstanceDimensionsFunc: method is nil but DatasetAPIClient.PatchInstanceDimensions was just called")
 	}
 	callInfo := struct {
 		Ctx              context.Context
 		ServiceAuthToken string
 		InstanceID       string
-		Data             dataset.OptionPost
+		Data             []*dataset.OptionPost
 		IfMatch          string
 	}{
 		Ctx:              ctx,
@@ -216,32 +216,32 @@ func (mock *DatasetAPIClientMock) PostInstanceDimensions(ctx context.Context, se
 		Data:             data,
 		IfMatch:          ifMatch,
 	}
-	lockDatasetAPIClientMockPostInstanceDimensions.Lock()
-	mock.calls.PostInstanceDimensions = append(mock.calls.PostInstanceDimensions, callInfo)
-	lockDatasetAPIClientMockPostInstanceDimensions.Unlock()
-	return mock.PostInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, data, ifMatch)
+	lockDatasetAPIClientMockPatchInstanceDimensions.Lock()
+	mock.calls.PatchInstanceDimensions = append(mock.calls.PatchInstanceDimensions, callInfo)
+	lockDatasetAPIClientMockPatchInstanceDimensions.Unlock()
+	return mock.PatchInstanceDimensionsFunc(ctx, serviceAuthToken, instanceID, data, ifMatch)
 }
 
-// PostInstanceDimensionsCalls gets all the calls that were made to PostInstanceDimensions.
+// PatchInstanceDimensionsCalls gets all the calls that were made to PatchInstanceDimensions.
 // Check the length with:
-//     len(mockedDatasetAPIClient.PostInstanceDimensionsCalls())
-func (mock *DatasetAPIClientMock) PostInstanceDimensionsCalls() []struct {
+//     len(mockedDatasetAPIClient.PatchInstanceDimensionsCalls())
+func (mock *DatasetAPIClientMock) PatchInstanceDimensionsCalls() []struct {
 	Ctx              context.Context
 	ServiceAuthToken string
 	InstanceID       string
-	Data             dataset.OptionPost
+	Data             []*dataset.OptionPost
 	IfMatch          string
 } {
 	var calls []struct {
 		Ctx              context.Context
 		ServiceAuthToken string
 		InstanceID       string
-		Data             dataset.OptionPost
+		Data             []*dataset.OptionPost
 		IfMatch          string
 	}
-	lockDatasetAPIClientMockPostInstanceDimensions.RLock()
-	calls = mock.calls.PostInstanceDimensions
-	lockDatasetAPIClientMockPostInstanceDimensions.RUnlock()
+	lockDatasetAPIClientMockPatchInstanceDimensions.RLock()
+	calls = mock.calls.PatchInstanceDimensions
+	lockDatasetAPIClientMockPatchInstanceDimensions.RUnlock()
 	return calls
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -85,10 +85,11 @@ var GetHealthCheck = func(cfg *config.Config, buildTime, gitCommit, version stri
 
 var GetCantabularClient = func(cfg *config.Config) CantabularClient {
 	return cantabular.NewClient(
-		dphttp.NewClient(),
 		cantabular.Config{
 			Host: cfg.CantabularURL,
 		},
+		dphttp.NewClient(),
+		nil,
 	)
 }
 


### PR DESCRIPTION
### What

- Upgrade dp-api-clients-go to version containing the PATCH instance dimensions method
- Send dimension options to dataset api in batches of up to a configurable size
- Refactored code, splitting the batch processing and patch send + retry in separate functions

The reason to use batch patching is to improve performance, as we expect the Census dataset to be very large.

Trello card:
https://trello.com/c/XHK9Ngr5/5183-in-dp-cantabular-import-dimension-options-replace-the-post-dimension-option-with-a-patch

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Make sure component tests pass
- (info only) Tested a cantabular import locally with dp-compose, which was successful and all dimension options were populated to mongoDB as expected.

### Who can review

anyone