### PR TITLE
use dp-api-clients-go tagged version: v2.1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12-0.20210824095131-dffc09423443
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12
 	github.com/ONSdigital/dp-component-test v0.3.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-import v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.40.0 h1:sAGie19I3/CZW8u+Bp2zTFSCmM32SQjayPibXEVBsLY=
 github.com/ONSdigital/dp-api-clients-go v1.40.0/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12-0.20210824095131-dffc09423443 h1:L7rV9JeLqn8GmVwItIDp56IQbxFUkI+o5PDVJ/lBYVU=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12-0.20210824095131-dffc09423443/go.mod h1:do31xNC5k22vAMnbnXGT9NH/7MLAsfR0qeTfiItw/mA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12 h1:tQHkPZwxCFZ+KhggwNhtwAOQ13pKwq9d4PkvjODP69Q=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.12/go.mod h1:do31xNC5k22vAMnbnXGT9NH/7MLAsfR0qeTfiItw/mA=
 github.com/ONSdigital/dp-component-test v0.3.1 h1:SAtMptv7m2+5RIBydo97RVESZETBRTd57jh3ngwrguo=
 github.com/ONSdigital/dp-component-test v0.3.1/go.mod h1:uf3ysJPRWHzi6YhNlN/vbhYr62w+zvGlNU/ublCDNgw=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=


### PR DESCRIPTION
### What

use tagged version of dp-api-clients-go 

### How to review

Make sure the version was updated in go.mod and go.sum (go mod tidy)

### Who can review

anyone