### PR TITLE
reduced the batch size to 100 to match dataset api MaxRequestOptions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ func Get() (*Config, error) {
 		CantabularHealthcheckEnabled:      false,
 		ServiceAuthToken:                  "",
 		ComponentTestUseLogFile:           false,
-		BatchSizeLimit:                    250, // maximum number of values sent to dataset APIs in a single patch call
+		BatchSizeLimit:                    100, // maximum number of values sent to dataset APIs in a single patch call (note that this value must be lower or equal to dataset api's `MaxRequestOptions`)
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,7 +37,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.ServiceAuthToken, ShouldEqual, "")
 				So(cfg.ComponentTestUseLogFile, ShouldBeFalse)
-				So(cfg.BatchSizeLimit, ShouldEqual, 250)
+				So(cfg.BatchSizeLimit, ShouldEqual, 100)
 			})
 
 			Convey("Then a second call to config should return the same config", func() {


### PR DESCRIPTION
### What

Merge release branch change back to develop:
- reduced the batch size to 100 to match dataset api MaxRequestOptions

### How to review

- Make sure only the expected commit is present

### Who can review

anyone