### PR TITLE
Use cantabular label for variable name

### DIFF
--- a/handler/category_dimension_import.go
+++ b/handler/category_dimension_import.go
@@ -155,7 +155,7 @@ func (h *CategoryDimensionImport) BatchPatchInstance(ctx context.Context, e *eve
 		optionsBatch := make([]*dataset.OptionPost, size)
 		for j := 0; j < size; j++ {
 			optionsBatch[j] = &dataset.OptionPost{
-				Name:     dim.Variable.Name,
+				Name:     dim.Variable.Label,
 				CodeList: dim.Variable.Name,             // TODO can we assume this?
 				Code:     dim.Categories[offset+j].Code, // TODO can we assume this?
 				Option:   dim.Categories[offset+j].Code,

--- a/handler/category_dimension_import_test.go
+++ b/handler/category_dimension_import_test.go
@@ -97,14 +97,14 @@ func TestHandle(t *testing.T) {
 						Option:   "code1",
 						Label:    "Code 1",
 						CodeList: "test-variable",
-						Name:     "test-variable",
+						Name:     "Test Variable",
 					},
 					{
 						Code:     "code2",
 						Option:   "code2",
 						Label:    "Code 2",
 						CodeList: "test-variable",
-						Name:     "test-variable",
+						Name:     "Test Variable",
 					},
 				})
 
@@ -117,7 +117,7 @@ func TestHandle(t *testing.T) {
 						Option:   "code3",
 						Label:    "Code 3",
 						CodeList: "test-variable",
-						Name:     "test-variable",
+						Name:     "Test Variable",
 					},
 				})
 			})
@@ -327,14 +327,14 @@ func TestHandle(t *testing.T) {
 						Option:   "code1",
 						Label:    "Code 1",
 						CodeList: "test-variable",
-						Name:     "test-variable",
+						Name:     "Test Variable",
 					},
 					{
 						Code:     "code2",
 						Option:   "code2",
 						Label:    "Code 2",
 						CodeList: "test-variable",
-						Name:     "test-variable",
+						Name:     "Test Variable",
 					},
 				})
 
@@ -347,7 +347,7 @@ func TestHandle(t *testing.T) {
 						Option:   "code3",
 						Label:    "Code 3",
 						CodeList: "test-variable",
-						Name:     "test-variable",
+						Name:     "Test Variable",
 					},
 				})
 
@@ -360,7 +360,7 @@ func TestHandle(t *testing.T) {
 						Option:   "code3",
 						Label:    "Code 3",
 						CodeList: "test-variable",
-						Name:     "test-variable",
+						Name:     "Test Variable",
 					},
 				})
 			})


### PR DESCRIPTION
### What

Changed the import process to store the correct value for dimension name.. was previously using Cantabular's 'name' filed which is actually an ID, changed to 'label' which the human readable name.

### How to review

Check change makes sense, tests pass

### Who can review

Anyone
