### PR TITLE
Import dimension name instead of label (#5664)

### DIFF
--- a/handler/category_dimension_import.go
+++ b/handler/category_dimension_import.go
@@ -83,7 +83,7 @@ func (h *CategoryDimensionImport) Handle(ctx context.Context, workerID int, msg 
 	log.Info(ctx, "event received", logData)
 
 	// get instance state and check that it is in completed state
-	_, eTag, err := h.getCompletedInstance(ctx, e, headers.IfMatchAnyETag)
+	instance, eTag, err := h.getCompletedInstance(ctx, e, headers.IfMatchAnyETag)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func (h *CategoryDimensionImport) Handle(ctx context.Context, workerID int, msg 
 
 		// send variable values to dataset api in batches
 		dim := resp.Dataset.Table.Dimensions[0]
-		eTag, err = h.BatchPatchInstance(ctx, e, dim, eTag)
+		eTag, err = h.BatchPatchInstance(ctx, e, dim, instance, eTag)
 		if err != nil {
 			return fmt.Errorf("failed to send dimension options to dataset api in batched patches: %w", err)
 		}
@@ -147,17 +147,25 @@ func (h *CategoryDimensionImport) Handle(ctx context.Context, workerID int, msg 
 }
 
 // BatchPatchInstance sends new dimension options to Dataset API, corresponding to the provided Cantabular variable, in batches of up to BatchSizeLimit
-func (h *CategoryDimensionImport) BatchPatchInstance(ctx context.Context, e *event.CategoryDimensionImport, dim cantabular.Dimension, eTag string) (newETag string, err error) {
+func (h *CategoryDimensionImport) BatchPatchInstance(ctx context.Context, e *event.CategoryDimensionImport, dim cantabular.Dimension, inst dataset.Instance, eTag string) (newETag string, err error) {
 	// Get batch splits for provided items
 	numFullChunks := len(dim.Categories) / h.cfg.BatchSizeLimit
 	remainingSize := len(dim.Categories) % h.cfg.BatchSizeLimit
+
+	// Create a lookup of dimension ID's to names, so that we can
+	// use a Cantabular name (e.g. `siblings_3`) to map to the name
+	// stored against the dimension (e.g. `siblings`).
+	idNameLookup := map[string]string{}
+	for _, dimInst := range inst.Dimensions {
+		idNameLookup[dimInst.ID] = dimInst.Name
+	}
 
 	// processBatch is a nested func to process a batch starting at the provided offset, with the provided size
 	processBatch := func(offset, size int) {
 		optionsBatch := make([]*dataset.OptionPost, size)
 		for j := 0; j < size; j++ {
 			optionsBatch[j] = &dataset.OptionPost{
-				Name:     dim.Variable.Label,
+				Name:     idNameLookup[dim.Variable.Name],
 				CodeList: dim.Variable.Name,             // TODO can we assume this?
 				Code:     dim.Categories[offset+j].Code, // TODO can we assume this?
 				Option:   dim.Categories[offset+j].Code,

--- a/handler/category_dimension_import_test.go
+++ b/handler/category_dimension_import_test.go
@@ -39,10 +39,12 @@ var (
 	testJobID      = "test-job-id"
 	testBlob       = "test-blob"
 	ctx            = context.Background()
+	testDimID      = "city"
+	testDimName    = "geography"
 	testEvent      = &event.CategoryDimensionImport{
 		InstanceID:     testInstanceID,
 		JobID:          testJobID,
-		DimensionID:    "test-variable",
+		DimensionID:    testDimID,
 		CantabularBlob: testBlob,
 		IsGeography:    false,
 	}
@@ -76,7 +78,7 @@ func TestHandle(t *testing.T) {
 				So(ctblrClient.GetDimensionOptionsCalls(), ShouldHaveLength, 1)
 				So(ctblrClient.GetDimensionOptionsCalls()[0].Req, ShouldResemble, cantabular.GetDimensionOptionsRequest{
 					Dataset:        "test-blob",
-					DimensionNames: []string{"test-variable"},
+					DimensionNames: []string{testDimID},
 				})
 			})
 
@@ -97,15 +99,15 @@ func TestHandle(t *testing.T) {
 						Code:     "code1",
 						Option:   "code1",
 						Label:    "Code 1",
-						CodeList: "test-variable",
-						Name:     "Test Variable",
+						CodeList: testDimID,
+						Name:     testDimName,
 					},
 					{
 						Code:     "code2",
 						Option:   "code2",
 						Label:    "Code 2",
-						CodeList: "test-variable",
-						Name:     "Test Variable",
+						CodeList: testDimID,
+						Name:     testDimName,
 					},
 				})
 
@@ -117,8 +119,8 @@ func TestHandle(t *testing.T) {
 						Code:     "code3",
 						Option:   "code3",
 						Label:    "Code 3",
-						CodeList: "test-variable",
-						Name:     "Test Variable",
+						CodeList: testDimID,
+						Name:     testDimName,
 					},
 				})
 			})
@@ -311,16 +313,11 @@ func TestHandle(t *testing.T) {
 			}
 		}
 		datasetAPIClient.GetInstanceFunc = func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
-			inst := dataset.Instance{
-				Version: dataset.Version{
-					State: dataset.StateCompleted.String(),
-				},
-			}
 			switch len(datasetAPIClient.PatchInstanceDimensionsCalls()) {
 			case 0, 1:
-				return inst, testETag, nil
+				return testDatasetInstance, testETag, nil
 			default:
-				return inst, newETag, nil
+				return testDatasetInstance, newETag, nil
 			}
 		}
 		importAPIClient := importAPIClientHappy(false, false)
@@ -335,7 +332,7 @@ func TestHandle(t *testing.T) {
 				So(ctblrClient.GetDimensionOptionsCalls(), ShouldHaveLength, 1)
 				So(ctblrClient.GetDimensionOptionsCalls()[0].Req, ShouldResemble, cantabular.GetDimensionOptionsRequest{
 					Dataset:        "test-blob",
-					DimensionNames: []string{"test-variable"},
+					DimensionNames: []string{testDimID},
 				})
 			})
 
@@ -358,15 +355,15 @@ func TestHandle(t *testing.T) {
 						Code:     "code1",
 						Option:   "code1",
 						Label:    "Code 1",
-						CodeList: "test-variable",
-						Name:     "Test Variable",
+						CodeList: testDimID,
+						Name:     testDimName,
 					},
 					{
 						Code:     "code2",
 						Option:   "code2",
 						Label:    "Code 2",
-						CodeList: "test-variable",
-						Name:     "Test Variable",
+						CodeList: testDimID,
+						Name:     testDimName,
 					},
 				})
 
@@ -378,8 +375,8 @@ func TestHandle(t *testing.T) {
 						Code:     "code3",
 						Option:   "code3",
 						Label:    "Code 3",
-						CodeList: "test-variable",
-						Name:     "Test Variable",
+						CodeList: testDimID,
+						Name:     testDimName,
 					},
 				})
 
@@ -391,8 +388,8 @@ func TestHandle(t *testing.T) {
 						Code:     "code3",
 						Option:   "code3",
 						Label:    "Code 3",
-						CodeList: "test-variable",
-						Name:     "Test Variable",
+						CodeList: testDimID,
+						Name:     testDimName,
 					},
 				})
 			})
@@ -433,11 +430,7 @@ func TestHandleFailure(t *testing.T) {
 		ctblrClient := cantabularClientUnhappy()
 		datasetAPIClient := &mock.DatasetAPIClientMock{
 			GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
-				return dataset.Instance{
-					Version: dataset.Version{
-						State: dataset.StateCompleted.String(),
-					},
-				}, testETag, nil
+				return testDatasetInstance, testETag, nil
 			},
 			PutInstanceStateFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
 				return testETag, nil
@@ -478,11 +471,7 @@ func TestHandleFailure(t *testing.T) {
 		ctblrClient := cantabularInvalidResponse()
 		datasetAPIClient := &mock.DatasetAPIClientMock{
 			GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
-				return dataset.Instance{
-					Version: dataset.Version{
-						State: dataset.StateCompleted.String(),
-					},
-				}, testETag, nil
+				return testDatasetInstance, testETag, nil
 			},
 			PutInstanceStateFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
 				return testETag, nil
@@ -541,11 +530,7 @@ func TestHandleFailure(t *testing.T) {
 		importAPIClient := importAPIClientHappy(false, false)
 		datasetAPIClient := &mock.DatasetAPIClientMock{
 			GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
-				return dataset.Instance{
-					Version: dataset.Version{
-						State: dataset.StateCompleted.String(),
-					},
-				}, testETag, nil
+				return testDatasetInstance, testETag, nil
 			},
 			PutInstanceStateFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
 				return newETag, nil
@@ -614,11 +599,7 @@ func TestHandleFailure(t *testing.T) {
 			datasetAPIClient.GetInstanceFunc = func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
 				switch len(datasetAPIClient.GetInstanceCalls()) {
 				case 0:
-					return dataset.Instance{
-						Version: dataset.Version{
-							State: dataset.StateCompleted.String(),
-						},
-					}, testETag, nil
+					return testDatasetInstance, testETag, nil
 				default:
 					return dataset.Instance{
 						Version: dataset.Version{
@@ -809,13 +790,25 @@ var testDimensionOptionsResp = &cantabular.GetDimensionOptionsResponse{
 						{Code: "code3", Label: "Code 3"},
 					},
 					Variable: cantabular.VariableBase{
-						Name:  "test-variable",
-						Label: "Test Variable",
+						Name:  testDimID,
+						Label: testDimID,
 					},
 				},
 			},
 		},
 		// Size: 333,
+	},
+}
+
+var testDatasetInstance = dataset.Instance{
+	Version: dataset.Version{
+		Dimensions: []dataset.VersionDimension{
+			{
+				ID:   testDimID,
+				Name: testDimName,
+			},
+		},
+		State: dataset.StateCompleted.String(),
 	},
 }
 
@@ -853,11 +846,7 @@ func datasetAPIClientHappy() *mock.DatasetAPIClientMock {
 			return testETag, nil
 		},
 		GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
-			return dataset.Instance{
-				Version: dataset.Version{
-					State: dataset.StateCompleted.String(),
-				},
-			}, testETag, nil
+			return testDatasetInstance, testETag, nil
 		},
 	}
 }
@@ -868,11 +857,7 @@ func datasetAPIClientHappyLastDimension() *mock.DatasetAPIClientMock {
 			return testETag, nil
 		},
 		GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
-			return dataset.Instance{
-				Version: dataset.Version{
-					State: dataset.StateCompleted.String(),
-				},
-			}, testETag, nil
+			return testDatasetInstance, testETag, nil
 		},
 		PutInstanceStateFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
 			return newETag, nil


### PR DESCRIPTION
### What

<img width="1415" alt="2022-04-19 at 15 57 06" src="https://user-images.githubusercontent.com/3719745/164477139-90d1e013-1af8-4885-8651-1c99554ac59f.png">

Changes the import to use the generic dimension name (e.g. `geography`) over the label of a selection (e.g. `City`).

Resolves: [5664](https://trello.com/c/3TbBPTvY) (partial) 

### How to review

Confirm the change makes sense conceptually.

### Who can review

Anyone, but probably Team B.
