### PR TITLE
Changing dimension name to be lowercase otherwise will not always match

### DIFF
--- a/handler/category_dimension_import.go
+++ b/handler/category_dimension_import.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
@@ -165,13 +166,14 @@ func (h *CategoryDimensionImport) BatchPatchInstance(ctx context.Context, e *eve
 		optionsBatch := make([]*dataset.OptionPost, size)
 		for j := 0; j < size; j++ {
 			optionsBatch[j] = &dataset.OptionPost{
-				Name:     idNameLookup[dim.Variable.Name],
+				Name:     idNameLookup[strings.ToLower(dim.Variable.Name)],
 				CodeList: dim.Variable.Name,             // TODO can we assume this?
 				Code:     dim.Categories[offset+j].Code, // TODO can we assume this?
 				Option:   dim.Categories[offset+j].Code,
 				Label:    dim.Categories[offset+j].Label,
 			}
 		}
+
 		eTag, err = h.PatchInstanceDimensionsWithRetries(ctx, e, optionsBatch, eTag, 0)
 		if err != nil {
 			err = fmt.Errorf("error processing a batch of cantabular variable values as dimension options: %w", err)


### PR DESCRIPTION
### What

Added the ToLower for the dimension name check as different cantabular blobs have variable names in upper and lower case, and the import was not working for the Teaching-Dataset.  This should ensure the variable names and id's now match.

### How to review

Pull the branch down and run the import locally with recipes for Example and Teaching-Dataset blobs.

### Who can review

Anyone from team b.
