### PR TITLE
Updating dp-api-clients-go

### DIFF
--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -114,7 +114,7 @@ func (c *Component) theFollowingInstanceIsAvailable(id string, instance *godog.D
 }
 
 // theFollowingCantabularCategoriesAreAvailable generates a mocked response for Cantabular Server
-// GET /v1/codebook/{name} with the provided query
+// GET /v10/codebook/{name} with the provided query
 func (c *Component) theFollowingCantabularCategoriesAreAvailable(dataset string, variable string, cb *godog.DocString) error {
 	// Encode the graphQL query with the provided dataset and variables
 	var b bytes.Buffer

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -85,7 +85,7 @@ func (c *Component) importAPIIsHealthy() error {
 func (c *Component) cantabularServerIsHealthy() error {
 	const res = `{"status": "OK"}`
 	c.CantabularSrv.NewHandler().
-		Get("/v9/datasets").
+		Get("/v10/datasets").
 		Reply(http.StatusOK).
 		BodyString(res)
 	return nil
@@ -114,7 +114,7 @@ func (c *Component) theFollowingInstanceIsAvailable(id string, instance *godog.D
 }
 
 // theFollowingCantabularCategoriesAreAvailable generates a mocked response for Cantabular Server
-// GET /v9/codebook/{name} with the provided query
+// GET /v1/codebook/{name} with the provided query
 func (c *Component) theFollowingCantabularCategoriesAreAvailable(dataset string, variable string, cb *godog.DocString) error {
 	// Encode the graphQL query with the provided dataset and variables
 	var b bytes.Buffer

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.138.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.140.1
 	github.com/ONSdigital/dp-component-test v0.7.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-import v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,9 @@ github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5Nc
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.117.0 h1:F8VFk7f/cToCOfm3md6ZNMzNb1ddfoc94+24td0AjIE=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.117.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.138.0 h1:gDQFNwOFr5SW3M2IxlwKDRFxkMVCDqStlVhU9950YfE=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.138.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.140.1 h1:UMqLBu25kfSu+ECAuLGE1BWE+r9DuFooqInf/pKynbg=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.140.1/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-component-test v0.7.0 h1:VfAxUPDSSt106qxDVF9NQ/5S9GwJaiMDpwhQZ9lybOM=
 github.com/ONSdigital/dp-component-test v0.7.0/go.mod h1:6nvnxyPDFxEhVVIciXdMJ5e2nG8wS8XGhciCtuan5xo=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=


### PR DESCRIPTION
### What

Update of dp-api-clients-go package to include latest Cantabular version.

### How to review

Pull the latest version of the dp-cantabular-server and dp-cantabular-api-ext repos and run make setup. Then run the docker stack in dp-compose/cantabular-import and ensure that the create recipe and dataset import works as expected.

### Who can review

Anyone who is familiar with the Get Data stream.
